### PR TITLE
0.0.5a

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,8 @@ module.exports = {
   collectCoverage: true,
   collectCoverageFrom: [
     'src/**/*.js',
-    '!**/browser.js'
+    '!**/browser.js',
+    '!src/**/requestAdapter/*.js'
   ],
   coverageReporters: ['lcov', 'json']
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casperapi",
-  "version": "0.0.3a",
+  "version": "0.0.5a",
   "description": "js api for casper distributed fs infrastructure",
   "main": "dist/casper.node.js",
   "scripts": {
@@ -36,7 +36,7 @@
     "web3": "^1.0.0-beta.33",
     "webpack": "^4.6.0",
     "webpack-cli": "^2.0.14",
-    "webpack-dev-server": "^3.1.3",
+    "webpack-dev-server": "^3.1.4",
     "webpack-merge": "^4.1.2",
     "webpack-node-externals": "^1.7.2"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -12,9 +12,10 @@ const sc = {
 
 
 class Casper {
-  constructor(api, mode) {
-    // Later we will add more blockchains and use autodetection, etherium is default mode 
-    this.blockchain = mode || 'eth'
+  constructor(api, { blockchain='eth', mode='dev' } = {}) {
+    // Later we will add more blockchains and use autodetection, etherium is the default mode 
+    this.blockchain = blockchain
+    this.mode = mode
     if(this.blockchain === 'eth') this.blockchainAPI = api.eth || api
   }
 
@@ -28,12 +29,12 @@ class Casper {
   save(file, uuid = false) {
     return CasperPromise((resolve, reject, emit) => {
       if( ! utils.isFile(file)) {
-        throw new TypeError('casperapi: file type must be File | Blob | ArrayBuffer | Buffer')
+        throw new TypeError('casperapi: file type must be File | Blob | Buffer | stream.Readable')
       }
 
       utils.getFileSize(file)
         .then(fileSize => {
-          return sc[this.blockchain].getUploadNodes(this.blockchainAPI, { fileSize })
+          return sc[this.blockchain].getUploadNodes(this.blockchainAPI, { fileSize, mode: this.mode })
         })
         .then(ips => {
           emit('sc-connected')         
@@ -68,7 +69,7 @@ class Casper {
   delete(uuid) {
     return CasperPromise((resolve, reject, emit) => {
       sc[this.blockchain]
-        .getStoringNodes(this.blockchainAPI, { uuid })
+        .getStoringNodes(this.blockchainAPI, { uuid, mode: this.mode })
         .then(ips => {
           emit('sc-connected')
           requestAny('DELETE', `http://{host}:${REST_PORT}/casper/v0/file/${uuid}`, ips)
@@ -88,7 +89,7 @@ class Casper {
   getFile(uuid) {
     return CasperPromise((resolve, reject, emit) => {
       sc[this.blockchain]
-        .getStoringNodes(this.blockchainAPI, { uuid })
+        .getStoringNodes(this.blockchainAPI, { uuid, mode: this.mode })
         .then(ips => {
           emit('sc-connected')
           return ips
@@ -112,7 +113,7 @@ class Casper {
     return CasperPromise((resolve, reject, emit) => {
       let sharingNode = ''
       sc[this.blockchain]
-        .getStoringNodes(this.blockchainAPI, { uuid })
+        .getStoringNodes(this.blockchainAPI, { uuid, mode: this.mode })
         .then(ips => {
           emit('sc-connected')
           requestAny('POST', `http://{host}:${REST_PORT}/casper/v0/share/${uuid}`, ips)

--- a/src/utils/crypto/bs58.js
+++ b/src/utils/crypto/bs58.js
@@ -36,8 +36,6 @@ bs58.decode = S => {
   for(i in S) { //loop through each base58 character in the input string
       j = 0,                             //reset the byte iterator
       c = A.indexOf( S[i] );             //set the initial carry amount equal to the current base58 digit
-      if(c < 0)                          //see if the base58 digit lookup is invalid (-1)
-          return undefined;              //if invalid base58 digit, bail out and return undefined
       c || b.length ^ i ? i : b.push(0); //prepend the result array with a zero if the base58 digit is zero and non-zero characters haven't been seen yet (to ensure correct decode length)
       while(j in d || c) {               //start looping through the bytes until there are no more bytes and no carry amount
           n = d[j];                      //set the placeholder for the current byte

--- a/src/utils/file/node.js
+++ b/src/utils/file/node.js
@@ -6,12 +6,10 @@ const isFile = file => ( file instanceof Buffer
                       || file instanceof stream.Readable
 )
 
-const getFileSize = file => new Promise((resolve, reject) => {
-  if(file instanceof stream.Readable) return getStreamLength(file).then(resolve)
-  if(file instanceof Buffer) return resolve(file.byteLength)
-
-  reject(new Error('casperapi: Cannot compute file size'))
-})
+const getFileSize = file => {
+  if(file instanceof stream.Readable) return getStreamLength(file)
+  if(file instanceof Buffer) return new Promise((resolve => resolve(file.byteLength)))
+}
 
 
 module.exports = {

--- a/tests/hybrid/index.spec.js
+++ b/tests/hybrid/index.spec.js
@@ -1,0 +1,266 @@
+const { mockEth } = require('../sc_testing_utils')
+const { getFileSize, uuidToHash } = require('../../src/utils')
+const CasperPromise = require('../../src/promise')
+
+let mockRequest = jest.fn()
+jest.mock('../../src/requestAny', () => function() {
+  return mockRequest.apply(this, arguments)
+})
+
+const Casper = require('../../src/index')
+
+
+const testGettingStoringNodes = method => {
+  it('gets stroing nodes from sc', async done => {
+    const uuid = '12sdadsa21414sdad5'
+    const showStoringPeers = jest.fn().mockReturnValue([])
+    const web3 = {eth: mockEth({
+      showStoringPeers
+    })}
+    
+    const casperapi = new Casper(web3)
+    await casperapi[method](uuid)
+
+    expect(showStoringPeers).toHaveBeenCalledWith(uuidToHash(uuid))
+    done()
+  })
+}
+
+
+// Would separate this into 2 more atomic test suites later
+describe('casperapi', () => {
+  let file
+  let uuid = '12sdadsa21414sdad5'
+  beforeEach(() => {
+    file = new Buffer('sample')
+    mockRequest = jest.fn().mockReturnValueOnce(CasperPromise(r => r('{}')))
+  })
+  
+
+  it('passes web3 to sc', async done => {
+    const getPeers = jest.fn().mockReturnValue({})
+    const web3 = {eth: mockEth({
+      getPeers
+    })}
+    
+    const casperapi = new Casper(web3)
+    await casperapi.save(file)
+
+    expect(getPeers).toHaveBeenCalled()
+    done()
+  })
+
+
+  describe('save', () => {
+    let web3, casperapi, getPeers
+
+    beforeEach(() => {
+      getPeers = jest.fn().mockReturnValue({})
+      web3 = {eth: mockEth({
+        getPeers
+      })}
+      casperapi = new Casper(web3)
+    })
+
+    it('calculates file size and passes it to sc (if file is new)', async done => {
+      const size = await getFileSize(file)
+      
+      await casperapi.save(file)
+  
+      expect(getPeers).toHaveBeenCalledWith(size)
+      done()  
+    })
+
+    it('passes the file to request strategy', async done => {
+      await casperapi.save(file)
+
+      expect(mockRequest.mock.calls[0][3].file).toBe(file)
+      done()
+    })
+
+    it('passes the hosts from sc to request strategy', async done => {
+      const ips = ['1.1.1.1', '2.2.2.2']
+      const getPeers = jest.fn().mockReturnValueOnce({
+        id1: 0,
+        id2: 1
+      })
+      const getIpPort = id => ips[id]
+      const localWeb3 = {eth: mockEth({
+        getPeers,
+        getIpPort
+      })}
+      const casperapi = new Casper(localWeb3)
+
+      await casperapi.save(file)
+
+      expect(mockRequest.mock.calls[0][2]).toEqual(ips)
+
+      done()
+    })
+
+    it('requests save from nodes (if file is new)', async done => {
+      await casperapi.save(file)
+      
+      expect(getPeers).toHaveBeenCalled()
+      expect(mockRequest.mock.calls[0][0]).toBe('POST')
+      done()
+    })
+
+    it('requests update from storing peers if (if file exists)', async done => {
+      const ips = ['1.1.1.1', '2.2.2.2']
+      const getPeers = jest.fn().mockReturnValueOnce({
+        id1: 0,
+        id2: 1
+      })
+      const getIpPort = id => ips[id]
+      const localWeb3 = {eth: mockEth({
+        getPeers,
+        getIpPort
+      })}
+      const casperapi = new Casper(localWeb3)
+
+      await casperapi.save(file, uuid)
+
+      const call = mockRequest.mock.calls[0]
+      expect(call[0]).toBe('PUT')
+      expect(call[1].endsWith('file/' + uuid)).toBe(true)
+      expect(mockRequest.mock.calls[0][2]).toEqual(ips)
+      done()
+    })
+
+    it(`resolves with file's uuid`, async done => {
+      const uuid = '12sdadsa21414sdad5'
+      mockRequest = jest.fn().mockReturnValueOnce(CasperPromise(r => r(`{ "UUID": "${uuid}" }`)))
+      
+      const returned = await casperapi.save(file)
+      
+      expect(returned).toEqual(uuid)
+      done()
+    })
+
+    it('emts upload progress', async done => {
+      mockRequest = jest.fn().mockImplementation(
+        () => CasperPromise((resolve, _, emit) => {
+          setTimeout(() => emit('progress', 0.1), 10)
+          setTimeout(() => {
+            emit('progress', 1)  
+            resolve('{}')
+          }, 20)
+        })
+      )
+      const logProgress = jest.fn()
+      await casperapi.save(file)
+                     .on('progress', logProgress)
+
+      expect(logProgress.mock.calls[0][0]).toBe(0.1)
+      expect(logProgress.mock.calls[1][0]).toBe(1)
+      done()
+    })
+
+    it('throws if file type is unsupported', () => {
+      expect(() => casperapi.save(10)).toThrow()
+      expect(getPeers).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('delete', () => {
+    beforeEach(() => {
+      showStoringPeers = jest.fn().mockReturnValue([])
+      web3 = {eth: mockEth({
+        showStoringPeers
+      })}
+      casperapi = new Casper(web3)
+    })
+
+    testGettingStoringNodes('delete')
+
+    it('requests file deletion', async done => {
+      await casperapi.delete(uuid)
+
+      const call = mockRequest.mock.calls[0]
+      expect(call[0]).toBe('DELETE')
+      expect(call[1].endsWith('file/' + uuid)).toBe(true)
+      done()
+    })
+  })
+
+  describe('getFile', () => {
+    let web3, casperapi, getPeers
+
+    beforeEach(() => {
+      showStoringPeers = jest.fn().mockReturnValue([])
+      web3 = {eth: mockEth({
+        showStoringPeers
+      })}
+      casperapi = new Casper(web3)
+    })
+
+    testGettingStoringNodes('getFile')
+
+    it('requests the file', async done => {
+      await casperapi.getFile(uuid)
+
+      const call = mockRequest.mock.calls[0]
+      expect(call[0]).toBe('GET')
+      expect(call[1].endsWith('file/' + uuid)).toBe(true)
+      done()
+    })
+
+    it('resolves with data returned from requestStrategy', async done => {
+      mockRequest = jest.fn().mockReturnValueOnce(CasperPromise(r => r(file)))
+
+      const returned = await casperapi.getFile(uuid)
+
+      expect(returned).toBe(file)
+      done()
+    })
+
+    it('emts download progress', async done => {
+      mockRequest = jest.fn().mockImplementation(
+        () => CasperPromise((resolve, _, emit) => {
+          setTimeout(() => emit('progress', 0.1), 10)
+          setTimeout(() => {
+            emit('progress', 1)  
+            resolve(file)
+          }, 20)
+        })
+      )
+      const logProgress = jest.fn()
+      await casperapi.getFile(uuid)
+                     .on('progress', logProgress)
+
+      expect(logProgress.mock.calls[0][0]).toBe(0.1)
+      expect(logProgress.mock.calls[1][0]).toBe(1)
+      done()
+    })
+  })
+
+  describe('getLink', () => {
+    beforeEach(() => {
+      showStoringPeers = jest.fn().mockReturnValue([])
+      web3 = {eth: mockEth({
+        showStoringPeers
+      })}
+      casperapi = new Casper(web3)
+    })
+
+    testGettingStoringNodes('getLink')
+
+    it('requests the sharing link', async done => {
+      await casperapi.getLink(uuid)
+
+      const call = mockRequest.mock.calls[0]
+      expect(call[0]).toBe('POST')
+      expect(call[1].endsWith('share/' + uuid)).toBe(true)
+      done()
+    })
+    it('resovle with the link returned form request strategy', async done => {
+      mockRequest = jest.fn().mockReturnValueOnce(CasperPromise(r => r(file)))
+
+      const returned = await casperapi.getFile(uuid)
+
+      expect(returned).toBe(file)
+      done()
+    })
+  })
+})

--- a/tests/node/utils.spec.js
+++ b/tests/node/utils.spec.js
@@ -17,7 +17,7 @@ describe('utils', () => {
     expect(utils.isFile('a string, not file at all')).toBe(false)
   })
 
-  it('has getFileSize that mesures ArrayBuffer, Buffer, stream.Readable', 
+  it('has getFileSize that mesures Buffer, stream.Readable', 
       done => {
     Promise.all([
       utils.getFileSize(sampleBuffer),

--- a/tests/sc_testing_utils.js
+++ b/tests/sc_testing_utils.js
@@ -1,0 +1,39 @@
+const makeMockMethod = handler => function() {
+  return {
+    call: ctx => new Promise(resolve => {
+      resolve(handler.apply(ctx, arguments))
+    })
+  }
+}
+
+const mockEth = ({
+  getPeers = () => {},
+  getIpPort = () => {},
+  showStoringPeers = () => {},
+}) => {
+  const mockSC = {
+    methods: {
+      getPeers: makeMockMethod(getPeers),
+      getIpPort: makeMockMethod(getIpPort),
+      showStoringPeers: makeMockMethod(showStoringPeers),
+    }
+  }
+
+  Contract = function() {
+    this.methods = mockSC.methods
+  }
+
+  Contract.prototype = Object.prototype
+
+  const eth = {
+    Contract
+  }
+
+  eth.cool = getPeers.cool
+
+  return eth
+}
+
+module.exports = {
+  mockEth
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7294,9 +7294,9 @@ webpack-cli@^2.0.14:
     yeoman-environment "^2.0.0"
     yeoman-generator "^2.0.3"
 
-webpack-dev-middleware@3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.1.2.tgz#be4d0c36a4fa7d69d6904093418514caa9df3a40"
+webpack-dev-middleware@3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.1.3.tgz#8b32aa43da9ae79368c1bf1183f2b6cf5e1f39ed"
   dependencies:
     loud-rejection "^1.6.0"
     memory-fs "~0.4.1"
@@ -7306,9 +7306,9 @@ webpack-dev-middleware@3.1.2:
     url-join "^4.0.0"
     webpack-log "^1.0.1"
 
-webpack-dev-server@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.1.3.tgz#5cecfd8a9d60c4638284813f1cf9562f04e5c1c5"
+webpack-dev-server@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.1.4.tgz#9a08d13c4addd1e3b6d8ace116e86715094ad5b4"
   dependencies:
     ansi-html "0.0.7"
     array-includes "^3.0.3"
@@ -7335,7 +7335,7 @@ webpack-dev-server@^3.1.3:
     spdy "^3.4.1"
     strip-ansi "^3.0.0"
     supports-color "^5.1.0"
-    webpack-dev-middleware "3.1.2"
+    webpack-dev-middleware "3.1.3"
     webpack-log "^1.1.2"
     yargs "11.0.0"
 


### PR DESCRIPTION
Added support for dev\prod modes
Added tests for sc && api
Removed ambigous bs58 branch
Refactored getFileSize
webpack-dev-server is now always a dev dependency (for playground to be usable)